### PR TITLE
Typo fixes and adding codespell pre-commit hook

### DIFF
--- a/.codespell-ignore.txt
+++ b/.codespell-ignore.txt
@@ -1,0 +1,11 @@
+ser
+conect
+struc
+aas
+nd
+coo
+fof
+winn
+als
+eles
+te

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,3 +88,13 @@ repos:
     hooks:
       - id: pylint
         name: "Static code analysis (pylint)"
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        name: codespell
+        description: Checks for common misspellings in text files.
+        entry: codespell --ignore-words=.codespell-ignore.txt
+        language: python
+        types: [text]

--- a/ProteinMPNN/README.md
+++ b/ProteinMPNN/README.md
@@ -11,7 +11,7 @@ CA only models: `ca_model_weights/v_48_002.pt, v_48_010.pt, v_48_020.pt`. Enable
 Helper scripts: `helper_scripts` - helper functions to parse PDBs, assign which chains to design, which residues to fix, adding AA bias, tying residues etc.
 
 Code organization:
-* `protein_mpnn_run.py` - the main script to initialialize and run the model.
+* `protein_mpnn_run.py` - the main script to initialize and run the model.
 * `protein_mpnn_utils.py` - utility functions for the main script.
 * `examples/` - simple code examples.
 * `inputs/` - input PDB files for examples
@@ -26,7 +26,7 @@ Input flags for `protein_mpnn_run.py`:
     argparser.add_argument("--model_name", type=str, default="v_48_020", help="ProteinMPNN model name: v_48_002, v_48_010, v_48_020, v_48_030; v_48_010=version with 48 edges 0.10A noise")
     argparser.add_argument("--seed", type=int, default=0, help="If set to 0 then a random seed will be picked;")
     argparser.add_argument("--save_score", type=int, default=0, help="0 for False, 1 for True; save score=-log_prob to npy files")
-    argparser.add_argument("--save_probs", type=int, default=0, help="0 for False, 1 for True; save MPNN predicted probabilites per position")
+    argparser.add_argument("--save_probs", type=int, default=0, help="0 for False, 1 for True; save MPNN predicted probabilities per position")
     argparser.add_argument("--score_only", type=int, default=0, help="0 for False, 1 for True; score input backbone-sequence pairs")
     argparser.add_argument("--conditional_probs_only", type=int, default=0, help="0 for False, 1 for True; output conditional probabilities p(s_i given the rest of the sequence and backbone)")
     argparser.add_argument("--conditional_probs_only_backbone", type=int, default=0, help="0 for False, 1 for True; if true output conditional probabilities p(s_i given backbone)")
@@ -40,12 +40,12 @@ Input flags for `protein_mpnn_run.py`:
     argparser.add_argument("--pdb_path", type=str, default='', help="Path to a single PDB to be designed")
     argparser.add_argument("--pdb_path_chains", type=str, default='', help="Define which chains need to be designed for a single PDB ")
     argparser.add_argument("--jsonl_path", type=str, help="Path to a folder with parsed pdb into jsonl")
-    argparser.add_argument("--chain_id_jsonl",type=str, default='', help="Path to a dictionary specifying which chains need to be designed and which ones are fixed, if not specied all chains will be designed.")
+    argparser.add_argument("--chain_id_jsonl",type=str, default='', help="Path to a dictionary specifying which chains need to be designed and which ones are fixed, if not specified all chains will be designed.")
     argparser.add_argument("--fixed_positions_jsonl", type=str, default='', help="Path to a dictionary with fixed positions")
     argparser.add_argument("--omit_AAs", type=list, default='X', help="Specify which amino acids should be omitted in the generated sequence, e.g. 'AC' would omit alanine and cystine.")
     argparser.add_argument("--bias_AA_jsonl", type=str, default='', help="Path to a dictionary which specifies AA composion bias if neededi, e.g. {A: -1.1, F: 0.7} would make A less likely and F more likely.")
     argparser.add_argument("--bias_by_res_jsonl", default='', help="Path to dictionary with per position bias.")
-    argparser.add_argument("--omit_AA_jsonl", type=str, default='', help="Path to a dictionary which specifies which amino acids need to be omited from design at specific chain indices")
+    argparser.add_argument("--omit_AA_jsonl", type=str, default='', help="Path to a dictionary which specifies which amino acids need to be omitted from design at specific chain indices")
     argparser.add_argument("--pssm_jsonl", type=str, default='', help="Path to a dictionary with pssm")
     argparser.add_argument("--pssm_multi", type=float, default=0.0, help="A value between [0.0, 1.0], 0.0 means do not use pssm, 1.0 ignore MPNN predictions")
     argparser.add_argument("--pssm_threshold", type=float, default=0.0, help="A value between -inf + inf to restric per position AAs")

--- a/ProteinMPNN/colab_notebooks/ca_only_quickdemo.ipynb
+++ b/ProteinMPNN/colab_notebooks/ca_only_quickdemo.ipynb
@@ -132,7 +132,7 @@
         "\n",
         "1) pdb: 6MRR, homomer: False, designed_chain: A\n",
         "\n",
-        "2) pdb: 1O91, homomer: True, designed_chain: A B C, for correct symmetric tying lenghts of homomer chains should be the same"
+        "2) pdb: 1O91, homomer: True, designed_chain: A B C, for correct symmetric tying lengths of homomer chains should be the same"
       ],
       "metadata": {
         "id": "bgRXscTaYuqM"
@@ -199,7 +199,7 @@
         "chain_list = list(set(designed_chain_list + fixed_chain_list))\n",
         "\n",
         "#@markdown - specified which chain(s) to design and which chain(s) to keep fixed. \n",
-        "#@markdown   Use comma:`A,B` to specifiy more than one chain\n",
+        "#@markdown   Use comma:`A,B` to specify more than one chain\n",
         "\n",
         "#chain = \"A\" #@param {type:\"string\"}\n",
         "#pdb_path_chains = chain\n",
@@ -215,7 +215,7 @@
         "\n",
         "\n",
         "save_score=0                      # 0 for False, 1 for True; save score=-log_prob to npy files\n",
-        "save_probs=0                      # 0 for False, 1 for True; save MPNN predicted probabilites per position\n",
+        "save_probs=0                      # 0 for False, 1 for True; save MPNN predicted probabilities per position\n",
         "score_only=0                      # 0 for False, 1 for True; score input backbone-sequence pairs\n",
         "conditional_probs_only=0          # 0 for False, 1 for True; output conditional probabilities p(s_i given the rest of the sequence and backbone)\n",
         "conditional_probs_only_backbone=0 # 0 for False, 1 for True; if true output conditional probabilities p(s_i given backbone)\n",
@@ -392,7 +392,7 @@
     {
       "cell_type": "code",
       "source": [
-        "#@markdown ### Amino acid probabilties\n",
+        "#@markdown ### Amino acid probabilities\n",
         "import plotly.express as px\n",
         "fig = px.imshow(np.exp(all_log_probs_concat).mean(0).T,\n",
         "                labels=dict(x=\"positions\", y=\"amino acids\", color=\"probability\"),\n",
@@ -510,7 +510,7 @@
         }
       ],
       "source": [
-        "#@markdown ### Sampling temperature adjusted amino acid probabilties\n",
+        "#@markdown ### Sampling temperature adjusted amino acid probabilities\n",
         "import plotly.express as px\n",
         "fig = px.imshow(all_probs_concat.mean(0).T,\n",
         "                labels=dict(x=\"positions\", y=\"amino acids\", color=\"probability\"),\n",

--- a/ProteinMPNN/colab_notebooks/quickdemo.ipynb
+++ b/ProteinMPNN/colab_notebooks/quickdemo.ipynb
@@ -132,7 +132,7 @@
         "\n",
         "1) pdb: 6MRR, homomer: False, designed_chain: A\n",
         "\n",
-        "2) pdb: 1O91, homomer: True, designed_chain: A B C, for correct symmetric tying lenghts of homomer chains should be the same"
+        "2) pdb: 1O91, homomer: True, designed_chain: A B C, for correct symmetric tying lengths of homomer chains should be the same"
       ],
       "metadata": {
         "id": "bgRXscTaYuqM"
@@ -198,7 +198,7 @@
         "chain_list = list(set(designed_chain_list + fixed_chain_list))\n",
         "\n",
         "#@markdown - specified which chain(s) to design and which chain(s) to keep fixed. \n",
-        "#@markdown   Use comma:`A,B` to specifiy more than one chain\n",
+        "#@markdown   Use comma:`A,B` to specify more than one chain\n",
         "\n",
         "#chain = \"A\" #@param {type:\"string\"}\n",
         "#pdb_path_chains = chain\n",
@@ -214,7 +214,7 @@
         "\n",
         "\n",
         "save_score=0                      # 0 for False, 1 for True; save score=-log_prob to npy files\n",
-        "save_probs=0                      # 0 for False, 1 for True; save MPNN predicted probabilites per position\n",
+        "save_probs=0                      # 0 for False, 1 for True; save MPNN predicted probabilities per position\n",
         "score_only=0                      # 0 for False, 1 for True; score input backbone-sequence pairs\n",
         "conditional_probs_only=0          # 0 for False, 1 for True; output conditional probabilities p(s_i given the rest of the sequence and backbone)\n",
         "conditional_probs_only_backbone=0 # 0 for False, 1 for True; if true output conditional probabilities p(s_i given backbone)\n",
@@ -390,7 +390,7 @@
     {
       "cell_type": "code",
       "source": [
-        "#@markdown ### Amino acid probabilties\n",
+        "#@markdown ### Amino acid probabilities\n",
         "import plotly.express as px\n",
         "fig = px.imshow(np.exp(all_log_probs_concat).mean(0).T,\n",
         "                labels=dict(x=\"positions\", y=\"amino acids\", color=\"probability\"),\n",
@@ -509,7 +509,7 @@
         }
       ],
       "source": [
-        "#@markdown ### Sampling temperature adjusted amino acid probabilties\n",
+        "#@markdown ### Sampling temperature adjusted amino acid probabilities\n",
         "import plotly.express as px\n",
         "fig = px.imshow(all_probs_concat.mean(0).T,\n",
         "                labels=dict(x=\"positions\", y=\"amino acids\", color=\"probability\"),\n",

--- a/ProteinMPNN/colab_notebooks/quickdemo_wAF2.ipynb
+++ b/ProteinMPNN/colab_notebooks/quickdemo_wAF2.ipynb
@@ -22,7 +22,7 @@
         "Examples: \n",
         "1.   pdb: `6MRR`, homomer: `False`, designed_chain: `A`\n",
         "2.   pdb: `1X2I`, homomer: `True`, designed_chain: `A,B` \n",
-        "     (for correct symmetric tying lenghts of homomer chains should be the same)"
+        "     (for correct symmetric tying lengths of homomer chains should be the same)"
       ]
     },
     {
@@ -148,7 +148,7 @@
         "chain_list = list(set(designed_chain_list + fixed_chain_list))\n",
         "\n",
         "#@markdown - specified which chain(s) to design and which chain(s) to keep fixed. \n",
-        "#@markdown   Use comma:`A,B` to specifiy more than one chain\n",
+        "#@markdown   Use comma:`A,B` to specify more than one chain\n",
         "\n",
         "#chain = \"A\" #@param {type:\"string\"}\n",
         "#pdb_path_chains = chain\n",
@@ -164,7 +164,7 @@
         "\n",
         "\n",
         "save_score=0                      # 0 for False, 1 for True; save score=-log_prob to npy files\n",
-        "save_probs=0                      # 0 for False, 1 for True; save MPNN predicted probabilites per position\n",
+        "save_probs=0                      # 0 for False, 1 for True; save MPNN predicted probabilities per position\n",
         "score_only=0                      # 0 for False, 1 for True; score input backbone-sequence pairs\n",
         "conditional_probs_only=0          # 0 for False, 1 for True; output conditional probabilities p(s_i given the rest of the sequence and backbone)\n",
         "conditional_probs_only_backbone=0 # 0 for False, 1 for True; if true output conditional probabilities p(s_i given backbone)\n",

--- a/ProteinMPNN/examples/submit_example_5.sh
+++ b/ProteinMPNN/examples/submit_example_5.sh
@@ -22,7 +22,7 @@ path_for_fixed_positions=$output_dir"/fixed_pdbs.jsonl"
 path_for_tied_positions=$output_dir"/tied_pdbs.jsonl"
 chains_to_design="A C"
 fixed_positions="9 10 11 12 13 14 15 16 17 18 19 20 21 22 23, 10 11 18 19 20 22"
-tied_positions="1 2 3 4 5 6 7 8, 1 2 3 4 5 6 7 8" #two list must match in length; residue 1 in chain A and C will be sampled togther;
+tied_positions="1 2 3 4 5 6 7 8, 1 2 3 4 5 6 7 8" #two list must match in length; residue 1 in chain A and C will be sampled together;
 
 python ../helper_scripts/parse_multiple_chains.py --input_path=$folder_with_pdbs --output_path=$path_for_parsed_chains
 

--- a/ProteinMPNN/protein_mpnn_run.py
+++ b/ProteinMPNN/protein_mpnn_run.py
@@ -389,7 +389,7 @@ if __name__ == "__main__":
     argparser.add_argument("--seed", type=int, default=0, help="If set to 0 then a random seed will be picked;")
  
     argparser.add_argument("--save_score", type=int, default=0, help="0 for False, 1 for True; save score=-log_prob to npy files")
-    argparser.add_argument("--save_probs", type=int, default=0, help="0 for False, 1 for True; save MPNN predicted probabilites per position")
+    argparser.add_argument("--save_probs", type=int, default=0, help="0 for False, 1 for True; save MPNN predicted probabilities per position")
 
     argparser.add_argument("--score_only", type=int, default=0, help="0 for False, 1 for True; score input backbone-sequence pairs")
 
@@ -407,13 +407,13 @@ if __name__ == "__main__":
     argparser.add_argument("--pdb_path", type=str, default='', help="Path to a single PDB to be designed")
     argparser.add_argument("--pdb_path_chains", type=str, default='', help="Define which chains need to be designed for a single PDB ")
     argparser.add_argument("--jsonl_path", type=str, help="Path to a folder with parsed pdb into jsonl")
-    argparser.add_argument("--chain_id_jsonl",type=str, default='', help="Path to a dictionary specifying which chains need to be designed and which ones are fixed, if not specied all chains will be designed.")
+    argparser.add_argument("--chain_id_jsonl",type=str, default='', help="Path to a dictionary specifying which chains need to be designed and which ones are fixed, if not specified all chains will be designed.")
     argparser.add_argument("--fixed_positions_jsonl", type=str, default='', help="Path to a dictionary with fixed positions")
     argparser.add_argument("--omit_AAs", type=list, default='X', help="Specify which amino acids should be omitted in the generated sequence, e.g. 'AC' would omit alanine and cystine.")
     argparser.add_argument("--bias_AA_jsonl", type=str, default='', help="Path to a dictionary which specifies AA composion bias if neededi, e.g. {A: -1.1, F: 0.7} would make A less likely and F more likely.")
    
     argparser.add_argument("--bias_by_res_jsonl", default='', help="Path to dictionary with per position bias.") 
-    argparser.add_argument("--omit_AA_jsonl", type=str, default='', help="Path to a dictionary which specifies which amino acids need to be omited from design at specific chain indices")
+    argparser.add_argument("--omit_AA_jsonl", type=str, default='', help="Path to a dictionary which specifies which amino acids need to be omitted from design at specific chain indices")
     argparser.add_argument("--pssm_jsonl", type=str, default='', help="Path to a dictionary with pssm")
     argparser.add_argument("--pssm_multi", type=float, default=0.0, help="A value between [0.0, 1.0], 0.0 means do not use pssm, 1.0 ignore MPNN predictions")
     argparser.add_argument("--pssm_threshold", type=float, default=0.0, help="A value between -inf + inf to restric per position AAs")

--- a/ProteinMPNN/training/README.md
+++ b/ProteinMPNN/training/README.md
@@ -62,7 +62,7 @@ Input flags for `training.py`:
     argparser.add_argument("--reload_data_every_n_epochs", type=int, default=2, help="reload training data every n epochs")
     argparser.add_argument("--num_examples_per_epoch", type=int, default=1000000, help="number of training example to load for one epoch")
     argparser.add_argument("--batch_size", type=int, default=10000, help="number of tokens for one batch")
-    argparser.add_argument("--max_protein_length", type=int, default=10000, help="maximum length of the protein complext")
+    argparser.add_argument("--max_protein_length", type=int, default=10000, help="maximum length of the protein complex")
     argparser.add_argument("--hidden_dim", type=int, default=128, help="hidden model dimension")
     argparser.add_argument("--num_encoder_layers", type=int, default=3, help="number of encoder layers")
     argparser.add_argument("--num_decoder_layers", type=int, default=3, help="number of decoder layers")

--- a/ProteinMPNN/training/colab_training_example.ipynb
+++ b/ProteinMPNN/training/colab_training_example.ipynb
@@ -1035,7 +1035,7 @@
         "# argparser.add_argument(\"--reload_data_every_n_epochs\", type=int, default=2, help=\"reload training data every n epochs\")\n",
         "# argparser.add_argument(\"--num_examples_per_epoch\", type=int, default=1000000, help=\"number of training example to load for one epoch\")\n",
         "# argparser.add_argument(\"--batch_size\", type=int, default=10000, help=\"number of tokens for one batch\")\n",
-        "# argparser.add_argument(\"--max_protein_length\", type=int, default=10000, help=\"maximum length of the protein complext\")\n",
+        "# argparser.add_argument(\"--max_protein_length\", type=int, default=10000, help=\"maximum length of the protein complex\")\n",
         "# argparser.add_argument(\"--hidden_dim\", type=int, default=128, help=\"hidden model dimension\")\n",
         "# argparser.add_argument(\"--num_encoder_layers\", type=int, default=3, help=\"number of encoder layers\") \n",
         "# argparser.add_argument(\"--num_decoder_layers\", type=int, default=3, help=\"number of decoder layers\")\n",

--- a/ProteinMPNN/training/training.py
+++ b/ProteinMPNN/training/training.py
@@ -222,7 +222,7 @@ if __name__ == "__main__":
     argparser.add_argument("--reload_data_every_n_epochs", type=int, default=2, help="reload training data every n epochs")
     argparser.add_argument("--num_examples_per_epoch", type=int, default=1000000, help="number of training example to load for one epoch")
     argparser.add_argument("--batch_size", type=int, default=10000, help="number of tokens for one batch")
-    argparser.add_argument("--max_protein_length", type=int, default=10000, help="maximum length of the protein complext")
+    argparser.add_argument("--max_protein_length", type=int, default=10000, help="maximum length of the protein complex")
     argparser.add_argument("--hidden_dim", type=int, default=128, help="hidden model dimension")
     argparser.add_argument("--num_encoder_layers", type=int, default=3, help="number of encoder layers") 
     argparser.add_argument("--num_decoder_layers", type=int, default=3, help="number of decoder layers")

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -118,14 +118,14 @@ experiment:
 
   # Loss weights.
   trans_loss_weight: 1.0
-  # Seprate rotation loss to include explicit penalties
+  # Separate rotation loss to include explicit penalties
   # of errors in the axis and angle components of the loss.
   separate_rot_loss: True
-  # In case of sperating the rotation loss,
+  # In case of separating the rotation loss,
   # rot_loss_weight is applied only for angle loss.
   rot_loss_weight: 0.5
   # The rotation loss is considered when t > rot_loss_t_threshold.
-  # The rot_loss_t_threshold is only applied for the angle in the rotation seperation case.
+  # The rot_loss_t_threshold is only applied for the angle in the rotation separation case.
   rot_loss_t_threshold: 0.2
   trans_x0_threshold: 1.0
   coordinate_scaling: ${diffuser.r3.coordinate_scaling}

--- a/config/evaluation.yaml
+++ b/config/evaluation.yaml
@@ -64,7 +64,7 @@ metrics:
     - gt
 
 reindex:
-  # Path to find exisiting PDB with non-contigious residue indices
+  # Path to find existing PDB with non-contiguous residue indices
   in_path: ???
   # Path to where to save updated PDBs
   out_path: ???

--- a/evaluation/eval_denovo.py
+++ b/evaluation/eval_denovo.py
@@ -237,7 +237,7 @@ def write_samples_pdbs(
         outdir: output directory to write files.
 
     Returns:
-        List of writen files.
+        List of written files.
     """
     all_list_paths = []
     for directory in data_path.glob("length_*"):

--- a/evaluation/evaluate_tcr.py
+++ b/evaluation/evaluate_tcr.py
@@ -608,7 +608,7 @@ def evaluation_plot(
         metric_names = metric_cfg[metric_type]
         for metric_name in metric_names:
             if metric_type == "residue_group_metrics":
-                # handle angles seperately.
+                # handle angles separately.
                 for angle in DIHEDRAL_ANGLES:
                     metric = f"{metric_name}_{angle}"
                     try:

--- a/evaluation/residue_reindex.py
+++ b/evaluation/residue_reindex.py
@@ -15,7 +15,7 @@ from evaluation.utils.directory_parser import traverse_prediction_dir
 def get_residue_map(
     model: Model,
 ) -> dict[str, list[tuple[tuple[str, int, str], tuple[str, int, str]]]]:
-    """Calculate residue mapping such that the output residue indices are contigious.
+    """Calculate residue mapping such that the output residue indices are contiguous.
 
     Args:
         model: Biopython.PDB Model to calculate mapping for.
@@ -25,8 +25,8 @@ def get_residue_map(
             returned tuples are a pair of the form (old_index, new_index).
             old_index and new_index take the form of the full residue indexing scheme
             used by BioPython - (hetero flag, sequence identifier, insertion code)
-            new indicies are of the form (" ", idx, " ") where the idx values are
-            contigious and start from zero, i.e. 0,1,2,3,4,5,... for each chain.
+            new indices are of the form (" ", idx, " ") where the idx values are
+            contiguous and start from zero, i.e. 0,1,2,3,4,5,... for each chain.
 
     """
     res_map: dict[str, list[tuple[tuple[str, int, str], tuple[str, int, str]]]] = {}

--- a/evaluation/utils/metrics.py
+++ b/evaluation/utils/metrics.py
@@ -1250,7 +1250,7 @@ def convert_to_eval_idx(vals: Sequence[T]) -> dict[int, T]:
 
     Returns:
         dict of the form {-4: vals[-4], ... , -1: vals[-1], 1: vals[0] 2: vals[1],...}.
-        dictionary keys do not "overlap". i.e. vals[-4] will only be accessable with
+        dictionary keys do not "overlap". i.e. vals[-4] will only be accessible with
         the -4 key and cannot be accessed using a positively valued key.
     """
     val_dict = {}

--- a/experiments/inference.py
+++ b/experiments/inference.py
@@ -7,7 +7,6 @@ Sample command:
 from __future__ import annotations
 
 import datetime
-import os
 import pathlib
 import shutil
 import subprocess

--- a/framedipt/data/process_pdb_files.py
+++ b/framedipt/data/process_pdb_files.py
@@ -58,7 +58,7 @@ def process_file(file_path: pathlib.Path, write_dir: pathlib.Path) -> dict[str, 
 
     Raises:
         DataError if a known filtering rule is hit.
-        All other errors are unexpected and are propogated.
+        All other errors are unexpected and are propagated.
     """
     metadata: dict[str, Any] = {}
     pdb_name = file_path.stem

--- a/framedipt/diffusion/r3_diffuser.py
+++ b/framedipt/diffusion/r3_diffuser.py
@@ -315,7 +315,7 @@ class R3Diffuser:
         x_reference_scaled = self._scale(x_reference)
         # We're going to handle the diffuse mask slightly differently here.
         # If our inpaint regions contain NaNs (because we don't know their values),
-        # we don't want them to propogate, and 0 * NaN = NaN, so we can't just
+        # we don't want them to propagate, and 0 * NaN = NaN, so we can't just
         # multiply by the mask.
         if diffuse_mask is not None:
             bool_mask = diffuse_mask.astype(bool)

--- a/framedipt/model/score_network.py
+++ b/framedipt/model/score_network.py
@@ -241,7 +241,7 @@ class ScoreNetwork(nn.Module):
             input_aatype=self._model_conf.input_aatype,
         )
 
-        # Initial embeddings of positonal and relative indices.
+        # Initial embeddings of positional and relative indices.
         init_node_embed, init_edge_embed = self.embedding_layer(
             seq_idx=input_feats["seq_idx"],
             t=input_feats["t"],

--- a/framedipt/tools/log.py
+++ b/framedipt/tools/log.py
@@ -1,10 +1,6 @@
 """Module for providing a configured logger."""
 from __future__ import annotations
 
-import os
-
-import neptune
-import omegaconf
 from absl import logging
 
 

--- a/openfold/utils/rigid_utils.py
+++ b/openfold/utils/rigid_utils.py
@@ -1165,10 +1165,10 @@ class Rigid:
 
     def to_tensor_4x4(self) -> torch.Tensor:
         """
-            Converts a transformation to a homogenous transformation tensor.
+            Converts a transformation to a homogeneous transformation tensor.
 
             Returns:
-                A [*, 4, 4] homogenous transformation tensor
+                A [*, 4, 4] homogeneous transformation tensor
         """
         tensor = self._trans.new_zeros((*self.shape, 4, 4))
         tensor[..., :3, :3] = self._rots.get_rot_mats()
@@ -1181,11 +1181,11 @@ class Rigid:
         t: torch.Tensor
     ):
         """
-            Constructs a transformation from a homogenous transformation
+            Constructs a transformation from a homogeneous transformation
             tensor.
 
             Args:
-                t: [*, 4, 4] homogenous transformation tensor
+                t: [*, 4, 4] homogeneous transformation tensor
             Returns:
                 T object with shape [*]
         """

--- a/tests/integration/test_inference.py
+++ b/tests/integration/test_inference.py
@@ -1,10 +1,8 @@
 """Integration test for the inference scripts."""
-import datetime
 import pathlib
 import shutil
 
 import hydra
-import pytest
 
 from experiments import inference
 


### PR DESCRIPTION
I fixed some typos that were discovered by running [ `codespell`](https://github.com/codespell-project/codespell) on the repository.

False positives flagged by `codespell` were added to [`.codespell-ignore.txt`](https://github.com/BioGeek/FrameDiPT/blob/typo-fixes/.codespell-ignore.txt).

I also added a [codespell pre-commit hook](https://github.com/BioGeek/FrameDiPT/blob/b7f9dd26c555418ccbd865426ea6f0d877f39078/.pre-commit-config.yaml#L92), to faster catch typos in the future.

Some no-longer needed imports were also removed by running `pre-commit` on the codebase.